### PR TITLE
Update for SMAPI 3.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_style = tab

--- a/StackToNearbyChests.sln
+++ b/StackToNearbyChests.sln
@@ -5,6 +5,14 @@ VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackToNearbyChests", "StackToNearbyChests\StackToNearbyChests.csproj", "{1DBB18A2-011D-402D-BF14-6291358F1AE2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{D82AA19C-9316-458E-AB5F-3DE77D1F20A4}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/StackToNearbyChests.sln
+++ b/StackToNearbyChests.sln
@@ -16,13 +16,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Debug|x86.Build.0 = Debug|Any CPU
 		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Release|x86.ActiveCfg = Release|x86
+		{1DBB18A2-011D-402D-BF14-6291358F1AE2}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StackToNearbyChests/ButtonHolder.cs
+++ b/StackToNearbyChests/ButtonHolder.cs
@@ -19,12 +19,12 @@ namespace StackToNearbyChests
 		{
 			ButtonHolder.inventoryPage = inventoryPage;
 
-			button = new ClickableTextureComponent("", 
-				new Rectangle(inventoryPage.xPositionOnScreen + width, inventoryPage.yPositionOnScreen + height / 3 - 64 + 8 + 80, 64, 64), 
+			button = new ClickableTextureComponent("",
+				new Rectangle(inventoryPage.xPositionOnScreen + width, inventoryPage.yPositionOnScreen + height / 3 - 64 + 8 + 80, 64, 64),
 				"",
-				"Stack to nearby chests", 
-				ButtonIcon, 
-				Rectangle.Empty, 
+				"Stack to nearby chests",
+				ButtonIcon,
+				Rectangle.Empty,
 				4f,
 				false)
 			{
@@ -37,7 +37,7 @@ namespace StackToNearbyChests
 			inventoryPage.organizeButton.downNeighborID = buttonID;
 			inventoryPage.trashCan.upNeighborID = buttonID;
 		}
-		
+
 		public static void ReceiveLeftClick(int x, int y)
 		{
 			if (button != null && button.containsPoint(x, y))

--- a/StackToNearbyChests/InventoryPage_Patcher.cs
+++ b/StackToNearbyChests/InventoryPage_Patcher.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Xna.Framework.Graphics;
+﻿using System;
+using Microsoft.Xna.Framework.Graphics;
 using StardewValley.Menus;
-using System;
 
 namespace StackToNearbyChests.Patches
 {
@@ -15,7 +15,7 @@ namespace StackToNearbyChests.Patches
 			0f).GetType();
 		public static Type SpriteBatch() => new Microsoft.Xna.Framework.Graphics.SpriteBatch(StardewValley.Game1.graphics.GraphicsDevice).GetType();
 	}
-	
+
 	class InventoryPage_Patcher_Constructor : Patch
 	{
 		public override Type GetTargetType() => typeof(InventoryPage);
@@ -27,7 +27,7 @@ namespace StackToNearbyChests.Patches
 			ButtonHolder.Constructor(__instance, x, y, width, height);
 		}
 	}
-	
+
 	class InventoryPage_Patcher_receiveLeftClick : Patch
 	{
 		public override Type GetTargetType() => TypeGetter.InventoryPage();
@@ -39,7 +39,7 @@ namespace StackToNearbyChests.Patches
 			ButtonHolder.ReceiveLeftClick(x, y);
 		}
 	}
-	
+
 	class InventoryPage_Patcher_draw : Patch
 	{
 		public override Type GetTargetType() => TypeGetter.InventoryPage();
@@ -51,7 +51,7 @@ namespace StackToNearbyChests.Patches
 			ButtonHolder.PostDraw(b);
 		}
 	}
-	
+
 	class InventoryPage_Patcher_performHoverAction : Patch
 	{
 		public override Type GetTargetType() => TypeGetter.InventoryPage();
@@ -63,7 +63,7 @@ namespace StackToNearbyChests.Patches
 			ButtonHolder.PerformHoverAction(x, y);
 		}
 	}
-	
+
 	class IClickableMenu_Patcher_populateClickableComponentList : Patch
 	{
 		public override Type GetTargetType() => TypeGetter.IClickableMenu();
@@ -76,7 +76,7 @@ namespace StackToNearbyChests.Patches
 				ButtonHolder.PopulateClickableComponentsList(inventoryPage);
 		}
 	}
-	
+
 	class ClickableTextureComponent_Patcher_Draw : Patch
 	{
 		public override Type GetTargetType() => TypeGetter.ClickableTextureComponent();

--- a/StackToNearbyChests/ModEntry.cs
+++ b/StackToNearbyChests/ModEntry.cs
@@ -13,7 +13,7 @@ namespace StackToNearbyChests
 			Config = helper.ReadConfig<ModConfig>();
 
 			ButtonHolder.ButtonIcon = helper.Content.Load<Texture2D>(@"icon.png");
-			
+
 			Patch.PatchAll(HarmonyInstance.Create("me.ilyaki.StackToNearbyChests"));
 		}
 	}

--- a/StackToNearbyChests/ModEntry.cs
+++ b/StackToNearbyChests/ModEntry.cs
@@ -1,19 +1,30 @@
 ﻿using Harmony;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
 
 namespace StackToNearbyChests
 {
+	/// <summary>The mod entry class loaded by SMAPI.</summary>
 	class ModEntry : Mod
 	{
 		internal static ModConfig Config { get; private set; }
 
+		/// <summary>The mod entry point, called after the mod is first loaded.</summary>
+		/// <param name="helper">Provides simplified APIs for writing mods.</param>
 		public override void Entry(IModHelper helper)
 		{
 			Config = helper.ReadConfig<ModConfig>();
-
 			ButtonHolder.ButtonIcon = helper.Content.Load<Texture2D>(@"icon.png");
 
+			helper.Events.GameLoop.GameLaunched += this.OnGameLaunched;
+		}
+
+		/// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+		/// <param name="sender">The event sender.</param>
+		/// <param name="e">The event data.</param>
+		private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+		{
 			Patch.PatchAll(HarmonyInstance.Create("me.ilyaki.StackToNearbyChests"));
 		}
 	}

--- a/StackToNearbyChests/Patch.cs
+++ b/StackToNearbyChests/Patch.cs
@@ -1,7 +1,7 @@
-﻿using Harmony;
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
+using Harmony;
 
 namespace StackToNearbyChests
 {
@@ -22,10 +22,10 @@ namespace StackToNearbyChests
 
 		public void ApplyPatch(HarmonyInstance harmonyInstance)
 		{
-			MethodBase targetMethod = String.IsNullOrEmpty(GetTargetMethodName()) ? 
-				(MethodBase)GetTargetType().GetConstructor(GetTargetMethodArguments()) : 
+			MethodBase targetMethod = String.IsNullOrEmpty(GetTargetMethodName()) ?
+				(MethodBase)GetTargetType().GetConstructor(GetTargetMethodArguments()) :
 				targetMethod = GetTargetType().GetMethod(GetTargetMethodName(), GetTargetMethodArguments());
-				
+
 			harmonyInstance.Patch(targetMethod, new HarmonyMethod(GetType().GetMethod("Prefix")), new HarmonyMethod(GetType().GetMethod("Postfix")));
 		}
 

--- a/StackToNearbyChests/StackLogic.cs
+++ b/StackToNearbyChests/StackLogic.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Buildings;
 using StardewValley.Locations;
 using StardewValley.Objects;
-using System;
-using System.Collections.Generic;
 
 namespace StackToNearbyChests
 {

--- a/StackToNearbyChests/StackToNearbyChests.csproj
+++ b/StackToNearbyChests/StackToNearbyChests.csproj
@@ -29,6 +29,24 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>

--- a/StackToNearbyChests/StackToNearbyChests.csproj
+++ b/StackToNearbyChests/StackToNearbyChests.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\DLLs\0Harmony.dll</HintPath>
+      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/StackToNearbyChests/StackToNearbyChests.csproj
+++ b/StackToNearbyChests/StackToNearbyChests.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>StackToNearbyChests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,6 +29,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>..\..\..\..\..\DLLs\0Harmony.dll</HintPath>
@@ -55,22 +56,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/StackToNearbyChests/manifest.json
+++ b/StackToNearbyChests/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Stack to Nearby Chests",
    "Author": "Ilyaki",
-   "Version": "1.4.4",
+   "Version": "1.4.5",
    "Description": "Adds a button that stacks all items from your inventory into chests that have at least 1x of the item",
    "UniqueID": "Ilyaki.StackToNearbyChests",
    "EntryDll": "StackToNearbyChests.dll",

--- a/StackToNearbyChests/manifest.json
+++ b/StackToNearbyChests/manifest.json
@@ -1,5 +1,5 @@
 ﻿{
-   "Name": "StackToNearbyChests",
+   "Name": "Stack to Nearby Chests",
    "Author": "Ilyaki",
    "Version": "1.4.4",
    "Description": "Adds a button that stacks all items from your inventory into chests that have at least 1x of the item",

--- a/StackToNearbyChests/packages.config
+++ b/StackToNearbyChests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
SMAPI 3.0 will load mods much earlier, so `Entry` will be called before the game is fully initialised. This PR updates the code to handle that (and it'll work fine before 3.0 too).

This pull request mainly...
* updates the code for SMAPI 3.0;
* updates the mod build package and migrates to the new package reference format;
* adds an `.editorconfig` to keep indent style consistent;
* fixes a hardcoded Harmony DLL path.

Let me know if you want me to change anything!